### PR TITLE
Improve communication with IOC

### DIFF
--- a/software/IOC files/protocol/SPIxCONV.proto
+++ b/software/IOC files/protocol/SPIxCONV.proto
@@ -1,105 +1,178 @@
 # SPIxCONV.proto
 
+@mismatch { in "%*#s"; in "%*#s"; }
+
 # Protocol for SPIxCONV boards. Developed for SPIxCONV version 1.1 and newer
 # Protocol doesn't have any terminator character
-Terminator = "";
+Terminator = CR LF;
 
 # An outcoming message should wait at most 10 s to be sent
 LockTimeout = 10000;
 
 # The timeout involved in reading operations is 25 ms
-ReadTimeout = 25;
+#ReadTimeout = 500;
+ReadTimeout = 5;
 
 # The application should wait at most 100 ms for a board to answer
+#ReplyTimeout = 1000;
 ReplyTimeout = 100;
 
 #==============================================================================
 config{
     # output parameters: board
     out 0x01, $1;
+    in 0x01, 0x01;
 }
 #==============================================================================
 set_portA_direction_bit{
     # output parameters: board, bit, value
     out 0x01, $1, "A", $2, "%(RVAL)i";
+    in 0x01, 0x01;
 }
 set_portB_direction_bit{
     # output parameters: board, bit, value
     out 0x01, $1, "B", $2, "%(RVAL)i";
+    in 0x01, 0x01;
 }
 set_portC_direction_bit{
     # output parameters: board, bit, value
     out 0x01, $1, "C", $2, "%(RVAL)i";
+    in 0x01, 0x01;
 }
 set_portD_direction_bit{
     # output parameters: board, bit, value
     out 0x01, $1, "D", $2, "%(RVAL)i";
+    in 0x01, 0x01;
 }
 #==============================================================================
 set_analog_output{
+    @init{
+        # output parameters: board
+        out 0x10, "\$1,", "\$2,", "\$3,", "\$4,";
+        # input parameters:  code set
+        in 0x10, 0x01, "%u";
+    }
     # output parameters: board, voltage
     out 0x02, $1, "%(RVAL)i";
+    in 0x02, 0x01;
+}
+#==============================================================================
+set_analog_output_2{
+    #@init{
+    #    read_analog_output_2;
+    #}
+    out 0x22, 0x00, "%u";
+    in 0x22, 0x01;
+}
+#==============================================================================
+set_analog_output_3{
+    #@init{
+    #    read_analog_output_3;
+    #}
+    out 0x32, 0x00, "%u";
+    in 0x32, 0x01;
 }
 #==============================================================================
 read_analog_output{
+    @init{
+        # output parameters: board
+        out 0x03, $1;
+        # input parameters:  code set
+        in 0x03, 0x01, "%u";
+    }
     # output parameters: board
     out 0x03, $1;
     # input parameters:  code set
-    in "%u";
+    in 0x03, 0x01, "%u";
+}
+#==============================================================================
+read_analog_output_2{
+    out 0x23, 0x00;
+    in 0x23, 0x01, "%u";
+}
+#==============================================================================
+read_analog_output_3{
+    out 0x33, 0x00;
+    in 0x33, 0x01, "%u";
 }
 #==============================================================================
 read_analog_input{
     # output parameters: board
     out 0x04, $1;
     # input parameters:  raw voltage
-    in "%u";
+    in 0x04, 0x01, "%u";
+}
+#==============================================================================
+read_analog_input_2{
+    out 0x24, 0x00;
+    in 0x24, 0x01, "%u";
+}
+#==============================================================================
+read_analog_input_3{
+    out 0x34, 0x00;
+    in 0x34, 0x01, "%u";
 }
 #==============================================================================
 set_digital_output_byte{
     # output parameters: board, value
     out 0x05, $1, $2;
+    in 0x05, 0x01;
 }
 #==============================================================================
 read_digital_input_byte{
+    #MaxInput = 3;
     # output parameters: board
     out 0x07, $1;
     # input parameters:  byte read
-    in "%d";
+    in 0x07, 0x01, "%d";
 }
 #==============================================================================
 reset{
     # output parameters: board
     out 0x09, $1, "%(RVAL)i";
+    in 0x09, 0x01;
 }
 #==============================================================================
 read_interlock_labels{
     Separator = ",";
     out 0x0A;
-    in "%#s";
+    in 0x0A, 0x01, "%#s";
 }
 #==============================================================================
 read_portB_digital_output_bit{
+    #MaxInput = 3;
     # output parameters: board, bit
     out 0x0B, $1, $2;
     # input parameters:  bit read
-    in "%u";
+    in 0x0B, 0x01, "%u";
 }
 #==============================================================================
 set_portB_digital_output_bit{
+    #MaxInput = 3;
+    @init{
+        # output parameters: board, bit
+        out 0x0B, $1, $2;
+        # input parameters:  bit read
+        in 0x0B, 0x01, "%u";
+    }
+
     # output parameters: board, bit, value
     out 0x0C, $1, $2, "%(RVAL)i";
+    in 0x0C, 0x01;
 }
 #==============================================================================
 read_portA_digital_input_bit{
+    #MaxInput = 3;
     # output parameters: board, bit_pos
-    out 0x0D, $1, $2;
+    out 0x11, $1, $2;
     # input parameters:  bit read
-    in "%u";
+    in 0x11, 0x01, "%u";
 }
 #==============================================================================
 read_portB_digital_input_bit{
+    #MaxInput = 3;
     # output parameters: board, bit_pos
     out 0x0E, $1, $2;
     # input parameters:  bit read
-    in "%u";
+    in 0x0E, 0x01, "%u";
 }

--- a/software/scripts/spixconv_unix_socket.py
+++ b/software/scripts/spixconv_unix_socket.py
@@ -884,9 +884,8 @@ def write_to_list():
                                 # If a valid command was decoded
                                 if response_payload is not None:
                                     if isinstance(response_payload, unicode):
-                                            response_payload_bytes = response_payload.encode('latin1') 
-                                            # test if this really happens 
-                                            # after that remove and amend 
+                                        response_payload_bytes = response_payload.encode('latin1') 
+                                        logger_debug.warning("Uneexpected type for response_payload :{}".format(type(response_payload)))
                                     elif isinstance(response_payload, str):
                                         response_payload_bytes = response_payload
                                     else:
@@ -898,9 +897,9 @@ def write_to_list():
                                     response = response_payload_bytes + "\r\n"
                                     #response = response_payload + chr(checksum) + "\r\n"
                                     
-                                    # remove and amend 
-                                    raw_hex = " ".join("0x{:02X}".format(ord(c)) for c in data) 
-                                    logger.info("Command: 0x{:02X} | Raw input: {!r} | Raw hex: {} | Response payload: {!r} | Full response: {!r}".format(ord(data[0]), data, raw_hex, response_payload_bytes, response))
+                                    # Debug raw hex
+                                    #raw_hex = " ".join("0x{:02X}".format(ord(c)) for c in data) 
+                                    #logger.info("Command: 0x{:02X} | Raw input: {!r} | Raw hex: {} | Response payload: {!r} | Full response: {!r}".format(ord(data[0]), data, raw_hex, response_payload_bytes, response))
 
                                     # Transmit it 
                                     connection.sendall(response)

--- a/software/scripts/spixconv_unix_socket.py
+++ b/software/scripts/spixconv_unix_socket.py
@@ -565,7 +565,9 @@ if __name__ == '__main__':
                 raise
     #----------------------------
     # identify board address:
-    for addr in range(255):
+    # TEST ONLY
+    #for addr in range(255):
+    for addr in list(range(10, -1, -1)):
         if(flash.ID_read(addr) == 4):
             board_address = addr
             break


### PR DESCRIPTION
This PR brings some improvements to the project. Most importantly

1. Improved socket protocol header: Responses to IOC now follow the format `[command][status][data]\r\n` with explicit command tracking. The status byte is currently hardcoded to success (0x01). Checksum handling and proper error handling will be introduced in a future update.

Also, this adds some minor refactoring 

2. Added the current .proto file used by the IOC for reference.
3. Updated a loop structure to match an unmerged modification from the `logging` branch, ensuring consistency between branches.
4. Removed outdated comments from `spixconv_unix_socket.py` for clarity.
5. Refactored `spixconv_unix_socket.py` by moving some functions out of its main block.  

*Apologies for the messy diffs in commit bc9a3f36004609e60a69e620a3ab986edca2ce03. All relevant changes are just function moves and added global tags. For this commit, I would recommend reviewing the final version of `spixconv_unix_socket.py` rather than using the diffs.*

### Testing
These changes have been tested in three separate environments for a few days: The spare setup at Rack Room 20, the test setup at Ímãs II, and InjNLK in production. In all cases, the updates appear stable.
